### PR TITLE
feat(OIDC): added scoped roles for oidc

### DIFF
--- a/aws/env/production/ot2_pd_oidc_role.tf
+++ b/aws/env/production/ot2_pd_oidc_role.tf
@@ -1,0 +1,70 @@
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "githubuser_ot2_role_production_default" {
+  name        = "githubuser_ot2_role-production-default"
+  description = "OIDC role for OT2 Protocol Designer deploys from Opentrons/opentrons-ot2"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:Opentrons/opentrons-ot2:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "githubuser_ot2_role_production_default_policy" {
+  name = "githubuser_ot2_role-production-default-policy"
+  role = aws_iam_role.githubuser_ot2_role_production_default.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowBucketLevelOpsForOt2PdBuckets"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [module.protocol_designer_bucket.bucket_arn]
+      },
+      {
+        Sid    = "AllowObjectLevelOpsForOt2PdBuckets"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+      },
+      {
+        Sid    = "AllowCloudFrontInvalidationsForOt2Pd"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:GetInvalidation",
+          "cloudfront:CreateInvalidation"
+        ]
+        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+      }
+    ]
+  })
+}

--- a/aws/env/production/ot2_pd_oidc_role.tf
+++ b/aws/env/production/ot2_pd_oidc_role.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_production_default_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = [module.protocol_designer_bucket.bucket_arn]
+        Resource = [module.ot2_protocol_designer_bucket.bucket_arn]
       },
       {
         Sid    = "AllowObjectLevelOpsForOt2PdBuckets"
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_production_default_policy" {
           "s3:DeleteObject",
           "s3:AbortMultipartUpload"
         ]
-        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+        Resource = ["${module.ot2_protocol_designer_bucket.bucket_arn}/*"]
       },
       {
         Sid    = "AllowCloudFrontInvalidationsForOt2Pd"
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_production_default_policy" {
           "cloudfront:GetInvalidation",
           "cloudfront:CreateInvalidation"
         ]
-        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+        Resource = [module.ot2_protocol_designer_cloudfront_distribution.distribution_arn]
       }
     ]
   })

--- a/aws/env/production/outputs.tf
+++ b/aws/env/production/outputs.tf
@@ -164,3 +164,8 @@ output "production_components_nameservers" {
   description = "Production components nameservers for delegation"
   value       = aws_route53_zone.components.name_servers
 }
+
+output "ot2_pd_deploy_oidc_role_arn" {
+  description = "OIDC IAM role ARN for OT2 Protocol Designer production deploys"
+  value       = aws_iam_role.githubuser_ot2_role_production_default.arn
+}

--- a/aws/env/sandbox/ot2_pd_oidc_role.tf
+++ b/aws/env/sandbox/ot2_pd_oidc_role.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_sandbox_default_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = [module.protocol_designer_bucket.bucket_arn]
+        Resource = [module.ot2_protocol_designer_bucket.bucket_arn]
       },
       {
         Sid    = "AllowObjectLevelOpsForSandboxOt2PdBucket"
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_sandbox_default_policy" {
           "s3:DeleteObject",
           "s3:AbortMultipartUpload"
         ]
-        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+        Resource = ["${module.ot2_protocol_designer_bucket.bucket_arn}/*"]
       },
       {
         Sid    = "AllowCloudFrontInvalidationsForSandboxOt2Pd"
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_sandbox_default_policy" {
           "cloudfront:GetInvalidation",
           "cloudfront:CreateInvalidation"
         ]
-        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+        Resource = [module.ot2_protocol_designer_cloudfront_distribution.distribution_arn]
       }
     ]
   })

--- a/aws/env/sandbox/ot2_pd_oidc_role.tf
+++ b/aws/env/sandbox/ot2_pd_oidc_role.tf
@@ -1,0 +1,70 @@
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "githubuser_ot2_role_sandbox_default" {
+  name        = "githubuser_ot2_role-sandbox-default"
+  description = "OIDC role for OT2 Protocol Designer sandbox deploys from Opentrons/opentrons-ot2"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:Opentrons/opentrons-ot2:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "githubuser_ot2_role_sandbox_default_policy" {
+  name = "githubuser_ot2_role-sandbox-default-policy"
+  role = aws_iam_role.githubuser_ot2_role_sandbox_default.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowBucketLevelOpsForSandboxOt2PdBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [module.protocol_designer_bucket.bucket_arn]
+      },
+      {
+        Sid    = "AllowObjectLevelOpsForSandboxOt2PdBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+      },
+      {
+        Sid    = "AllowCloudFrontInvalidationsForSandboxOt2Pd"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:GetInvalidation",
+          "cloudfront:CreateInvalidation"
+        ]
+        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+      }
+    ]
+  })
+}

--- a/aws/env/sandbox/outputs.tf
+++ b/aws/env/sandbox/outputs.tf
@@ -114,3 +114,8 @@ output "sandbox_components_cloudfront_url" {
   description = "Sandbox components CloudFront URL"
   value       = "https://${module.components_cloudfront_distribution.distribution_domain_name}"
 }
+
+output "ot2_pd_deploy_oidc_role_arn" {
+  description = "OIDC IAM role ARN for OT2 Protocol Designer sandbox deploys"
+  value       = aws_iam_role.githubuser_ot2_role_sandbox_default.arn
+}

--- a/aws/env/staging/ot2_pd_oidc_role.tf
+++ b/aws/env/staging/ot2_pd_oidc_role.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_staging_default_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = [module.protocol_designer_bucket.bucket_arn]
+        Resource = [module.ot2_protocol_designer_bucket.bucket_arn]
       },
       {
         Sid    = "AllowObjectLevelOpsForStagingOt2PdBucket"
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_staging_default_policy" {
           "s3:DeleteObject",
           "s3:AbortMultipartUpload"
         ]
-        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+        Resource = ["${module.ot2_protocol_designer_bucket.bucket_arn}/*"]
       },
       {
         Sid    = "AllowCloudFrontInvalidationsForStagingOt2Pd"
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy" "githubuser_ot2_role_staging_default_policy" {
           "cloudfront:GetInvalidation",
           "cloudfront:CreateInvalidation"
         ]
-        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+        Resource = [module.ot2_protocol_designer_cloudfront_distribution.distribution_arn]
       }
     ]
   })

--- a/aws/env/staging/ot2_pd_oidc_role.tf
+++ b/aws/env/staging/ot2_pd_oidc_role.tf
@@ -1,0 +1,70 @@
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "githubuser_ot2_role_staging_default" {
+  name        = "githubuser_ot2_role-staging-default"
+  description = "OIDC role for OT2 Protocol Designer staging deploys from Opentrons/opentrons-ot2"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:Opentrons/opentrons-ot2:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "githubuser_ot2_role_staging_default_policy" {
+  name = "githubuser_ot2_role-staging-default-policy"
+  role = aws_iam_role.githubuser_ot2_role_staging_default.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowBucketLevelOpsForStagingOt2PdBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [module.protocol_designer_bucket.bucket_arn]
+      },
+      {
+        Sid    = "AllowObjectLevelOpsForStagingOt2PdBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = ["${module.protocol_designer_bucket.bucket_arn}/*"]
+      },
+      {
+        Sid    = "AllowCloudFrontInvalidationsForStagingOt2Pd"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:GetInvalidation",
+          "cloudfront:CreateInvalidation"
+        ]
+        Resource = [module.protocol_designer_cloudfront_distribution.distribution_arn]
+      }
+    ]
+  })
+}

--- a/aws/env/staging/outputs.tf
+++ b/aws/env/staging/outputs.tf
@@ -119,3 +119,8 @@ output "staging_protocol_designer_nameservers" {
   description = "Staging protocol designer nameservers for delegation"
   value       = data.aws_route53_zone.protocol_designer.name_servers
 }
+
+output "ot2_pd_deploy_oidc_role_arn" {
+  description = "OIDC IAM role ARN for OT2 Protocol Designer staging deploys"
+  value       = aws_iam_role.githubuser_ot2_role_staging_default.arn
+}


### PR DESCRIPTION
### Fix OT2 PD OIDC IAM policies to scope access to OT2-only resources in each environment.

Update production, staging, and sandbox ot2_pd_oidc_role.tf files to use module.ot2_protocol_designer_bucket and module.ot2_protocol_designer_cloudfront_distribution ARNs.

Remove unintended permissions to monorepo PD bucket/distribution resources.